### PR TITLE
Fixed build.zig

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -4,60 +4,29 @@ pub fn build(b: *std.Build) !void {
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
 
-    const lib_mod = b.createModule(.{
+    const dep = b.dependency("VulkanMemoryAllocator", .{});
+    const mod = b.addModule("zig_vma", .{
         .root_source_file = b.path("src/root.zig"),
         .target = target,
         .optimize = optimize,
+        .link_libcpp = true,
     });
-
-    const lib = b.addLibrary(.{
-        .linkage = .static,
-        .name = "zw_vma",
-        .root_module = lib_mod,
-    });
-
-    // ------------------------------------------------------------------------
-    // START: Vulkan memory allocator
-    // ------------------------------------------------------------------------
-    lib.linkLibCpp(); // VMA is a CPP library.
-
-    const dep = b.dependency("VulkanMemoryAllocator", .{});
-    const include_path = dep.path("include");
-
-    // Generate implementation
-    const impl = try std.fs.createFileAbsolute(
-        try dep.path("vma.cc").getPath3(
-            b,
-            &lib.step,
-        ).toString(b.allocator),
-        .{},
-    );
-    try impl.writeAll(
-        \\#define VMA_IMPLEMENTATION
-        \\#define VMA_STATIC_VULKAN_FUNCTIONS 0
-        \\#include <vk_mem_alloc.h>
-    );
-    impl.close();
-
-    lib.addCSourceFile(.{
-        .file = dep.path("vma.cc"),
+    mod.addIncludePath(dep.path("include"));
+    mod.addCSourceFile(.{
+        .file = b.addWriteFiles().add("vma.cc",
+            \\#define VMA_IMPLEMENTATION
+            \\#define VMA_STATIC_VULKAN_FUNCTIONS 0
+            \\#include <vk_mem_alloc.h>
+        ),
         .flags = &.{"-std=c++17"},
     });
-    lib.addIncludePath(include_path);
-    // ------------------------------------------------------------------------
-    // END: Vulkan memory allocator
-    // ------------------------------------------------------------------------
-
-    b.installArtifact(lib);
 
     // Creates a step for unit testing. This only builds the test executable
     // but does not run it.
-    const lib_unit_tests = b.addTest(.{
-        .root_module = lib_mod,
+    const unit_tests = b.addTest(.{
+        .root_module = mod,
     });
-
-    const run_lib_unit_tests = b.addRunArtifact(lib_unit_tests);
-
+    const run_unit_tests = b.addRunArtifact(unit_tests);
     const test_step = b.step("test", "Run unit tests");
-    test_step.dependOn(&run_lib_unit_tests.step);
+    test_step.dependOn(&run_unit_tests.step);
 }


### PR DESCRIPTION
The use of `b.addLibrary()` and `std.fs.createFileAbsolute()` are less than ideal. Actually you couldn't even consume the package because it didn't export any modlues. The prefered way of sharing code in zig is through the use of modlues, with `b.addModule()`. They are like `INTERFACE` libraries in cmake. You can bundle source files, c includes, link libraries and signal the dependence on libc/libcpp with them just as well as with static libraries, but they are easier to use by consumers because they don't need to also link the artifacts.